### PR TITLE
Add support for DVC 2.40.0

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -1,1 +1,1 @@
-Singularity.2.8.2
+Singularity.2.40.0

--- a/Singularity.2.40.0
+++ b/Singularity.2.40.0
@@ -1,0 +1,14 @@
+Bootstrap: docker
+From: rockylinux:8
+
+%labels
+Maintainer eric.burgueno@plantandfood.co.nz
+Version 2.40.0
+
+%post
+  ## Install official RPM
+  yum -y install https://github.com/iterative/dvc/releases/download/2.40.0/dvc-2.40.0-1.x86_64.rpm
+  yum clean all
+  
+%runscript
+  exec dvc "$@"


### PR DESCRIPTION
Versions 2.0-2.8.2 had serious performance issues with files on network shares, as discussed in https://github.com/iterative/dvc/issues/6977 and https://github.com/iterative/dvc/issues/5562

The issues appear to be resolved from 2.8.3 and performance is good under 2.40.0

Who should the maintainer be now?